### PR TITLE
Add options for protecting branches

### DIFF
--- a/src/Models/ProjectRepository.js
+++ b/src/Models/ProjectRepository.js
@@ -14,10 +14,10 @@ class ProjectRepository extends BaseModel {
     return this.get(`projects/${pId}/repository/branches/${encodeURI(branchId)}`);
   }
 
-  protectBranch(projectId, branchId) {
+  protectBranch(projectId, branch, options) {
     const pId = Utils.parse(projectId);
-
-    return this.put(`projects/${pId}/repository/branches/${encodeURI(branchId)}/protect`);
+  
+    return this.put(`projects/${pId}/repository/branches/${encodeURI(branch)}/protect?developers_can_push=${options.developers_can_push}&developers_can_merge=${options.developers_can_merge}`);
   }
 
   unprotectBranch(projectId, branchId) {


### PR DESCRIPTION
Hello,

I have been using node-gitlabe-api to automate some Git Lab tasks for my team.   The main thing I needed was to be able to protect branches by passing the 'developer_can_merge' flag.  

Unfortunately our Git Lab version is one minor version (9.4 instead of 9.5) behind having support for the new protect_branches API available in v4.  So I've got to use this particular call.

Let me know if any questions