### PR TITLE
Add options for getting commits

### DIFF
--- a/src/Models/ProjectRepositoryCommitComments.js
+++ b/src/Models/ProjectRepositoryCommitComments.js
@@ -2,10 +2,10 @@ import BaseModel from './BaseModel';
 import { parse } from '../Utils';
 
 class ProjectRepositoryCommitComments extends BaseModel {
-  all(projectId, sha) {
+  all(projectId, sha, options = {}) {
     const pId = parse(projectId);
 
-    return this.get(`projects/${pId}/repository/commits/${sha}/comments`);
+    return this.get(`projects/${pId}/repository/commits/${sha}/comments`, options);
   }
 
   create(projectId, sha, note, options = {}) {

--- a/src/Models/ProjectRepositoryCommits.js
+++ b/src/Models/ProjectRepositoryCommits.js
@@ -9,10 +9,10 @@ class ProjectRepositoryCommits extends BaseModel {
     this.comments = new ProjectRepositoryCommitComments(...args);
   }
 
-  all(projectId) {
+  all(projectId, options = {}) {
     const pId = parse(projectId);
 
-    return this.get(`projects/${pId}/repository/commits`);
+    return this.get(`projects/${pId}/repository/commits`, options);
   }
 
   diff(projectId, sha) {


### PR DESCRIPTION
Add the options parameter to requests getting all commits and all commit comments.

This is needed in order to set the paging options (and others).

I believe this functionality was intended to be implemented as mentioned in the comment on issue #19.