### PR TITLE
Added project-repository-files docs page

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,3 +312,33 @@ inferred from the file path
 - Initial release
 - TODO: Tests, Examples
 
+## Development
+
+To get this running locally rather than from your `node_modules` folder:
+
+```bash
+$ git clone https://github.com/jdalrymple/node-gitlab-api.git
+$ cd node-gitlab-api
+$ npm install
+$ npm build
+```
+
+And then inside whatever project you are using `node-gitlab-api` in you change your references to use that repo.  In your package.json of that upstream project change:
+
+```json
+  "dependencies": {
+    ...
+    "node-gitlab-api": "2.1.0"
+    ...
+  }
+```
+
+to this
+
+```json
+  "dependencies": {
+    ...
+    "node-gitlab-api": "<path-to-your-clone>"
+    ...
+  }
+```

--- a/docs/project-repository-files.md
+++ b/docs/project-repository-files.md
@@ -8,7 +8,7 @@ Get file from repository
 
 ```javascript
 // From a project ID
-let file = GitlabAPI.projects.repository.files.show(projectId, encodeURIComponent( filePath ), branch );
+let file = GitlabAPI.projects.repository.files.show(projectId, filePath, branch );
 ```
 Parameters: [Get file from repository](https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/repository_files.md#get-file-from-repository)
 

--- a/docs/project-repository-files.md
+++ b/docs/project-repository-files.md
@@ -1,0 +1,14 @@
+## Project Repository Files
+
+* [Get a file](#get-a-file) 
+
+### Get a file
+
+Get file from repository
+
+```javascript
+// From a project ID
+let file = GitlabAPI.projects.repository.files.show(projectId, encodeURIComponent( filePath ), branch );
+```
+Parameters: [Get file from repository](https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/repository_files.md#get-file-from-repository)
+

--- a/src/Models/ProjectRepositoryFiles.js
+++ b/src/Models/ProjectRepositoryFiles.js
@@ -5,31 +5,31 @@ class ProjectRepositoryFiles extends BaseModel {
   create(projectId, filePath, branch, options = {}) {
     const pId = parse(projectId);
 
-    return this.post(`projects/${pId}/repository/files/${filePath}`, Object.assign({ branch }, options));
+    return this.post(`projects/${pId}/repository/files/${parse(filePath)}`, Object.assign({ branch }, options));
   }
 
   edit(projectId, filePath, branch, options = {}) {
     const pId = parse(projectId);
 
-    return this.put(`projects/${pId}/repository/files/${filePath}`, Object.assign({ branch }, options));
+    return this.put(`projects/${pId}/repository/files/${parse(filePath)}`, Object.assign({ branch }, options));
   }
 
   remove(projectId, filePath, branch, options = {}) {
     const pId = parse(projectId);
 
-    return this.delete(`projects/${pId}/repository/files/${filePath}`, Object.assign({ branch }, options));
+    return this.delete(`projects/${pId}/repository/files/${parse(filePath)}`, Object.assign({ branch }, options));
   }
 
   show(projectId, filePath, ref) {
     const pId = parse(projectId);
 
-    return this.get(`projects/${pId}/repository/files/${filePath}`, { ref });
+    return this.get(`projects/${pId}/repository/files/${parse(filePath)}`, { ref });
   }
 
   showRaw(projectId, filePath, ref) {
     const pId = parse(projectId);
 
-    return this.get(`projects/${pId}/repository/files/${filePath}/raw`, { ref });
+    return this.get(`projects/${pId}/repository/files/${parse(filePath)}/raw`, { ref });
   }
 }
 


### PR DESCRIPTION
Hi @jdalrymple I like this project over some other gitlab api projects and like that you're trying to document things within the project rather than assuming people can figure out the details of how to make the calls by reading the code.  

As I documented this call that I'm making I can't help but wonder if the `encodeURIComponent` should be part of this package rather than having users have to wrap their path in that.  I'd be happy to make that change but wanted to run it by you first.  Thoughts?