### PR TITLE
Added delete key method to UserKeys.js

### DIFF
--- a/src/Models/UserKeys.js
+++ b/src/Models/UserKeys.js
@@ -11,6 +11,13 @@ class UserKeys extends BaseModel {
     });
   }
 
+  delete(userId, keyId) {
+    const uId = parse(userId);
+    const kId = parse(keyId);
+
+    return super.delete(`users/${uId}/keys/${kId}`);
+  }
+
   all(userId) {
     const uId = parse(userId);
 

--- a/src/Models/UserKeys.js
+++ b/src/Models/UserKeys.js
@@ -11,11 +11,11 @@ class UserKeys extends BaseModel {
     });
   }
 
-  delete(userId, keyId) {
+  remove(userId, keyId) {
     const uId = parse(userId);
     const kId = parse(keyId);
 
-    return super.delete(`users/${uId}/keys/${kId}`);
+    return this.delete(`users/${uId}/keys/${kId}`);
   }
 
   all(userId) {


### PR DESCRIPTION
Just a small edit to `UserKeys.js` which allows to delete an SSH key from a User.

# Usage
`await gitlabApi.users.keys.remove(userId, userKey);`

# Gitlab Docs
https://docs.gitlab.com/ce/api/users.html#delete-ssh-key-for-given-user