### PR TITLE
Added optional parameters for adding and editing resource members

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,6 +8,7 @@
   ],
   "plugins": [
     "@babel/plugin-proposal-export-default-from",
-    "@babel/plugin-proposal-export-namespace-from"
+    "@babel/plugin-proposal-export-namespace-from",
+    "@babel/plugin-proposal-object-rest-spread"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build:clean": "rimraf -rf dist && mkdirp -p dist",
     "build:es6": "babel src -d dist/latest",
-    "build:es5": "babel src -d dist/es5  --no-babelrc --presets=@babel/env --plugins=@babel/plugin-proposal-export-default-from,@babel/plugin-proposal-export-namespace-from",
+    "build:es5": "babel src -d dist/es5  --no-babelrc --presets=@babel/env --plugins=@babel/plugin-proposal-export-default-from,@babel/plugin-proposal-export-namespace-from,@babel/plugin-proposal-object-rest-spread",
     "build": "npm run build:clean && npm run build:es6 && npm run build:es5",
     "prepublishOnly": "npm run build"
   },

--- a/src/templates/ResourceMembers.js
+++ b/src/templates/ResourceMembers.js
@@ -13,16 +13,17 @@ class ResourceMembers extends BaseService {
     return RequestHelper.get(this, `${this.resourceType}/${rId}/members`);
   }
 
-  add(resourceId, userId, accessLevel) {
+  add(resourceId, userId, accessLevel, options = {}) {
     const [rId, uId] = [resourceId, userId].map(encodeURIComponent);
 
     return RequestHelper.post(this, `${this.resourceType}/${rId}/members`, {
       user_id: uId,
       access_level: parseInt(accessLevel, 10),
+      ...options,
     });
   }
 
-  edit(resourceId, userId, accessLevel) {
+  edit(resourceId, userId, accessLevel, options = {}) {
     const [rId, uId] = [resourceId, userId].map(encodeURIComponent);
 
     return RequestHelper.put(
@@ -30,6 +31,7 @@ class ResourceMembers extends BaseService {
       `${this.resourceType}/${rId}/members/${uId}`,
       {
         access_level: parseInt(accessLevel, 10),
+        ...options,
       },
     );
   }


### PR DESCRIPTION
 I noticed that in the [resource members](https://github.com/jdalrymple/node-gitlab-api/blob/master/src/Models/ResourceMembers.js) class there is no support for optional params. More specifically, you can't add the [expires_at](https://docs.gitlab.com/ee/api/members.html#add-a-member-to-a-group-or-project) property to a request. Thought this could be a simple solution for optional parameters, which could be reused in other places. Happy to update documentation to reflect these changes if you like it!