### PR TITLE
Fix current user "keys" routes

### DIFF
--- a/src/services/UserKeys.js
+++ b/src/services/UserKeys.js
@@ -2,13 +2,13 @@ import { BaseService, RequestHelper } from '../infrastructure';
 
 class UserKeys extends BaseService {
   all({ userId }) {
-    const url = userId ? `users/${encodeURIComponent(userId)}/keys` : 'users/keys';
+    const url = userId ? `users/${encodeURIComponent(userId)}/keys` : 'user/keys';
 
     return RequestHelper.get(this, url);
   }
 
   create(title, key, { userId } = {}) {
-    const url = userId ? `users/${encodeURIComponent(userId)}/keys` : 'users/keys';
+    const url = userId ? `users/${encodeURIComponent(userId)}/keys` : 'user/keys';
 
     return RequestHelper.post(this, url, {
       title,
@@ -19,12 +19,12 @@ class UserKeys extends BaseService {
   show(keyId) {
     const kId = encodeURIComponent(keyId);
 
-    return RequestHelper.get(this, `users/keys/${kId}`);
+    return RequestHelper.get(this, `user/keys/${kId}`);
   }
 
   remove(keyId, { userId } = {}) {
     const kId = encodeURIComponent(keyId);
-    const url = userId ? `users/${encodeURIComponent(userId)}/keys` : 'users/keys';
+    const url = userId ? `users/${encodeURIComponent(userId)}/keys` : 'user/keys';
 
     return RequestHelper.delete(this, `${url}/${kId}`);
   }


### PR DESCRIPTION
As per the [docs](https://docs.gitlab.com/ee/api/keys.html), all user key routes have as a substring either `users/:id/keys` (plural `users` with `:id`) or `user/keys`(singular `user` with no user ID).

This PR fixes a typo where the latter form had `users` pluralized, which resulted in a 404 from Gitlab.com.