### PR TITLE
Fix broken `MergeRequestNotes` requests

### DIFF
--- a/src/services/MergeRequestNotes.js
+++ b/src/services/MergeRequestNotes.js
@@ -2,7 +2,7 @@ import { ResourceNotes } from '../templates';
 
 class MergeRequestNotes extends ResourceNotes {
   constructor(options) {
-    super('projects', 'mergerequests', options);
+    super('projects', 'merge_requests', options);
   }
 }
 


### PR DESCRIPTION
The correct resource name for Merge Request notes is `merge_requests` not `mergerequests`. See https://docs.gitlab.com/ee/api/notes.html#create-new-merge-request-note for reference.